### PR TITLE
Pin ADCore to commit adding compat with recent libxml2

### DIFF
--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -5,7 +5,7 @@ SRC_URL:=https://github.com/areaDetector
 
 # 2024-12-01
 SRC_NAME_ADCORE:=ADCore
-SRC_TAG_ADCORE:=R3-14
+SRC_TAG_ADCORE:=99fa6bf
 SRC_VER_ADCORE:=$(SRC_TAG_ADCORE)
 
 # 2024-04-07


### PR DESCRIPTION
See https://github.com/areaDetector/ADCore/pull/551

The above PR fixes support for recent versions of libxml2 included in Redhat 10 and and Rocky 10.

Until the next release cycle, this pin will pull the necessary change to allow ADCore to compile on Rocky/Redhat 10 without using ADSupport.